### PR TITLE
Major fixes for Linux onboarding

### DIFF
--- a/Utility/ARM/Enable-AutomationSolution.ps1
+++ b/Utility/ARM/Enable-AutomationSolution.ps1
@@ -444,6 +444,39 @@ try
             $MMAOStype = "OmsAgentForLinux"
             $MMATypeHandlerVersion = "1.7"
             Write-Output -InputObject "Deploying MMA agent to Linux VM"
+
+            $RunCommand = "sudo dmidecode | grep UUID"
+            $TempScript = New-TemporaryFile
+            $RunCommand | Out-File -FilePath $TempScript.FullName
+
+            # Fetch UUID from VM
+            Write-Output -InputObject "Retrieving internal UUID from Linux VM to use for onboarding to solution"
+            $ResultCommand = Invoke-AzureRMVMRunCommand -VM $NewVM -CommandId "RunShellScript" -ScriptPath $TempScript.FullName -ErrorAction Continue -ErrorVariable oErr
+            Remove-Item -Path $TempScript.FullName -Force
+            if ($oErr)
+            {
+                Remove-Item -Path $TempScript.FullName -Force
+                Write-Error -Message "Failed to run script command to retrieve VUUID from Linux VM" -ErrorAction Stop
+            }
+            else
+            {
+                if($ResultCommand.Status -eq "Succeeded")
+                {
+                    $VMId =(Select-String -InputObject $ResultCommand.value.message -Pattern '\w{8}-\w{4}-\w{4}-\w{4}-\w{12}').Matches.Groups.Value
+                    if($VMId)
+                    {
+                        Write-Output -InputObject "Linux VUUID is: $VMId. This is not the same as VMid as is the case for Windows VMs"
+                    }
+                    else
+                    {
+                        Write-Error -Message "VUUID for Linux VM was not extracted successfully" -ErrorAction Stop
+                    }
+                }
+                else
+                {
+                    Write-Error -Message "Failed to retrieve Linux VM VUUID from script command" -ErrorAction Stop
+                }
+            }
         }
         elseif ($NewVM.StorageProfile.OSDisk.OSType -eq "Windows")
         {
@@ -615,7 +648,7 @@ try
             if ($SolutionGroup.Properties.Query -match 'VMUUID')
             {
                 # Will leave the "" inside "VMUUID in~ () so can find out what is added by runbook (left of "") and what is added through portal (right of "")
-                $NewQuery = $SolutionGroup.Properties.Query.Replace('VMUUID in~ (', "VMUUID in~ (`"$($NewVM.VmId)`",")
+                $NewQuery = $SolutionGroup.Properties.Query.Replace('VMUUID in~ (', "VMUUID in~ (`"$VMId`",")
             }
             #Region Solution Onboarding ARM Template
             # ARM template to deploy log analytics agent extension for both Linux and Windows

--- a/Utility/ARM/Enable-AutomationSolution.ps1
+++ b/Utility/ARM/Enable-AutomationSolution.ps1
@@ -456,7 +456,7 @@ try
             if ($oErr)
             {
                 Remove-Item -Path $TempScript.FullName -Force
-                Write-Error -Message "Failed to run script command to retrieve VUUID from Linux VM" -ErrorAction Stop
+                Write-Error -Message "Failed to run script command to retrieve VMUUID from Linux VM" -ErrorAction Stop
             }
             else
             {
@@ -465,16 +465,16 @@ try
                     $VMId =(Select-String -InputObject $ResultCommand.value.message -Pattern '\w{8}-\w{4}-\w{4}-\w{4}-\w{12}').Matches.Groups.Value
                     if($VMId)
                     {
-                        Write-Output -InputObject "Linux VUUID is: $VMId. This is not the same as VMid as is the case for Windows VMs"
+                        Write-Output -InputObject "Linux VMUUID is: $VMId. This is not the same as VMid as is the case for Windows VMs"
                     }
                     else
                     {
-                        Write-Error -Message "VUUID for Linux VM was not extracted successfully" -ErrorAction Stop
+                        Write-Error -Message "VMUUID for Linux VM was not extracted successfully" -ErrorAction Stop
                     }
                 }
                 else
                 {
-                    Write-Error -Message "Failed to retrieve Linux VM VUUID from script command" -ErrorAction Stop
+                    Write-Error -Message "Failed to retrieve Linux VM VMUUID from script command" -ErrorAction Stop
                 }
             }
         }

--- a/Utility/ARM/Enable-AutomationSolutionAz.ps1
+++ b/Utility/ARM/Enable-AutomationSolutionAz.ps1
@@ -456,7 +456,7 @@ try
             if ($oErr)
             {
                 Remove-Item -Path $TempScript.FullName -Force
-                Write-Error -Message "Failed to run script command to retrieve VUUID from Linux VM" -ErrorAction Stop
+                Write-Error -Message "Failed to run script command to retrieve VMUUID from Linux VM" -ErrorAction Stop
             }
             else
             {
@@ -465,16 +465,16 @@ try
                     $VMId =(Select-String -InputObject $ResultCommand.value.message -Pattern '\w{8}-\w{4}-\w{4}-\w{4}-\w{12}').Matches.Groups.Value
                     if($VMId)
                     {
-                        Write-Output -InputObject "Linux VUUID is: $VMId. This is not the same as VMid as is the case for Windows VMs"
+                        Write-Output -InputObject "Linux VMUUID is: $VMId. This is not the same as VMid as is the case for Windows VMs"
                     }
                     else
                     {
-                        Write-Error -Message "VUUID for Linux VM was not extracted successfully" -ErrorAction Stop
+                        Write-Error -Message "VMUUID for Linux VM was not extracted successfully" -ErrorAction Stop
                     }
                 }
                 else
                 {
-                    Write-Error -Message "Failed to retrieve Linux VM VUUID from script command" -ErrorAction Stop
+                    Write-Error -Message "Failed to retrieve Linux VM VMUUID from script command" -ErrorAction Stop
                 }
             }
         }

--- a/Utility/ARM/Format-AutomationSolutionSearch.ps1
+++ b/Utility/ARM/Format-AutomationSolutionSearch.ps1
@@ -335,7 +335,7 @@ try
                     }
                     else
                     {
-                        Write-Warning -Message "Found Linux VMs, skipping VUUID cleanup as Linux VMid and VUUID is different"
+                        Write-Warning -Message "Found Linux VMs, skipping VMUUID cleanup as Linux VMid and VMUUID is different"
                     }
                 }
                 else

--- a/Utility/ARM/Format-AutomationSolutionSearchAz.ps1
+++ b/Utility/ARM/Format-AutomationSolutionSearchAz.ps1
@@ -336,7 +336,7 @@ try
                     }
                     else
                     {
-                        Write-Warning -Message "Found Linux VMs, skipping VUUID cleanup as Linux VMid and VUUID is different"
+                        Write-Warning -Message "Found Linux VMs, skipping VMUUID cleanup as Linux VMid and VMUUID is different"
                     }
                 }
                 else


### PR DESCRIPTION
Linux VM do not share the same identifier for VMid (from ARM) or the UUID set internally in the OS.
The downside is that Update management uses the UUID instead of the VMid, therefore onboarding for Linux VMs have not ever worked. 

This fix will run a script against Linux machines and retrieve the UUID and use this to unboard Linux machines.

Downside of this is that the cleanup script can no longer be allowed to clean VMUUIDs, this because it would remove the Linux entries as there are no way ARM can fetch these values when comparing if a VM is still operational or not.